### PR TITLE
Drop master on /dev/dri/card0 by default

### DIFF
--- a/osal/allocator/allocator_drm.c
+++ b/osal/allocator/allocator_drm.c
@@ -182,6 +182,11 @@ static MPP_RET os_allocator_drm_open(void **ctx, size_t alignment, MppAllocFlagT
         return MPP_ERR_UNKNOW;
     }
 
+    int ret = drm_ioctl(fd, DRM_IOCTL_DROP_MASTER, 0);
+    if (ret < 0) {
+        mpp_err_f("Drop master on %s failed!\n", dev_drm);
+    }
+
     drm_dbg_dev("open drm dev fd %d flags %x\n", fd, flags);
 
     p = mpp_malloc(allocator_ctx_drm, 1);


### PR DESCRIPTION
This is a really odd edge case, but if you initialize ffmpeg rockchip first and then later try to get the drm master to draw a user interface using another part of your program, you'll be unable to modeset.

This is because drm automatically sets the first file to open as the drm master.

Most people won't run into this issue (or I assume they won't) because they are already likely using a desktop environment (which will already claim the drm master), they are completely running as headless process, and/or they aren't initializing ffmpeg before their UI.

I was lucky enough to have none of those as my setup, so ran head first into this problem.

The other way around this is to open a temporary file to `/dev/dri/card0` before calling `av_hwframe_ctx_init` in your user code. In my experience, you can close the file after the `av_hwframe_ctx_init`